### PR TITLE
adding output_folder as parameter

### DIFF
--- a/kilt/ranker_evaluation.py
+++ b/kilt/ranker_evaluation.py
@@ -10,7 +10,23 @@ from kilt import kilt_utils as utils
 from kilt import eval_retrieval
 
 
-def run(test_config_json, ranker, model_name, logger, topk=100, debug=False, output_folder=""):
+def generate_output_file(output_folder, output_name, model_name, dataset_file):
+    basename = os.path.basename(dataset_file)
+    output_file = os.path.join(output_folder, output_name, model_name, basename)
+    if not os.path.exists(os.path.dirname(output_file)):
+        os.makedirs(os.path.dirname(output_file))
+    return output_file
+
+
+def run(
+    test_config_json,
+    ranker,
+    model_name,
+    logger,
+    topk=100,
+    debug=False,
+    output_folder="",
+):
 
     if debug:
         pp = pprint.PrettyPrinter(indent=4)
@@ -57,10 +73,12 @@ def run(test_config_json, ranker, model_name, logger, topk=100, debug=False, out
 
                 # write retrieved augmented data - for dpr, blink, drqa
                 if meta:
-                    basename = os.path.basename(dataset_file)
-                    output_file = os.path.join(output_folder, "retrieved_augmented_datasets", model_name, basename)
-                    if not os.path.exists(os.path.dirname(output_file)):
-                        os.makedirs(os.path.dirname(output_file))
+                    output_file = generate_output_file(
+                        output_folder,
+                        "retrieved_augmented_datasets",
+                        model_name,
+                        dataset_file,
+                    )
 
                     print(
                         "writing retrieved augmented output in {}".format(output_file),
@@ -78,11 +96,10 @@ def run(test_config_json, ranker, model_name, logger, topk=100, debug=False, out
 
                 # write predictions files for BLINK
                 if False and model_name == "blink" and meta:
-                    basename = os.path.basename(dataset_file)
-                    output_file = os.path.join(output_folder, "predictions", model_name, basename)
-                    if not os.path.exists(os.path.dirname(output_file)):
-                        os.makedirs(os.path.dirname(output_file))
-                    
+                    output_file = generate_output_file(
+                        output_folder, "predictions", model_name, dataset_file
+                    )
+
                     print(
                         "writing predictions in {}".format(output_file), flush=True,
                     )

--- a/scripts/evaluate_ranking.py
+++ b/scripts/evaluate_ranking.py
@@ -6,10 +6,14 @@ from kilt import kilt_utils as utils
 from kilt.retrievers import DrQA_tfidf, Solr_BM25, DPR_connector, BLINK_connector
 
 
-def execute(logger, test_config_json, retriever, log_directory, model_name, output_folder):
+def execute(
+    logger, test_config_json, retriever, log_directory, model_name, output_folder
+):
 
     # run evaluation
-    result = ranker_evaluation.run(test_config_json, retriever, model_name, logger, output_folder=output_folder)
+    result = ranker_evaluation.run(
+        test_config_json, retriever, model_name, logger, output_folder=output_folder
+    )
 
     # dump results on json file
     with open("{}/{}_result.json".format(log_directory, model_name), "w") as outfile:
@@ -62,7 +66,14 @@ def main(args):
         else:
             retriever = BLINK_connector.BLINK.from_default_config(args.model_name)
 
-    execute(logger, test_config_json, retriever, log_directory, args.model_name, output_folder=args.output_folder)
+    execute(
+        logger,
+        test_config_json,
+        retriever,
+        log_directory,
+        args.model_name,
+        args.output_folder,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding output_folder as argument to `scripts/evaluate_ranking.py`. Added in `kilt/ranker_evaluation.py` as well. If the folder does not exists, it creates one preventing errors.