### PR TITLE
recall computation

### DIFF
--- a/kilt/eval_retrieval.py
+++ b/kilt/eval_retrieval.py
@@ -78,18 +78,32 @@ def recall_at_k(datapoint, predicted_page_ids, k):
         for page in predicted_page_ids:
             page = str(page).strip()
             found = False
-            for e_set in evidence_sets:
+            for idx, e_set in enumerate(evidence_sets):
+
+                e_set_id = f"evidence_set:{idx}"
+
                 if page in e_set:
                     found = True
+
+                    # remove from the rank previous points referring to this evidence set
+                    if e_set_id in rank:
+                        rank.remove(e_set_id)
+
+                    # remove the page from the evidence set
                     e_set.remove(page)
+
                     if len(e_set) == 0:
                         # it was the last evidence, it counts as true in the rank
                         rank.append(True)
+                    else:
+                        # add a point for this partial evidence set
+                        rank.append(e_set_id)
+
             if not found:
                 rank.append(False)
 
         # 4. recall @ k
-        r = sum(rank[:k]) / denominator
+        r = rank[:k].count(True) / denominator
 
     return r
 


### PR DESCRIPTION
Implementation of evidence set aware recall.
A model should produce a list of page ids.
The core idea is to group page ids that belongs to the same evidence set (consider them as 1 in the rank).
Pages that are not evidence counts as 1 as well.

test:

python kilt/eval_retrieval.py /checkpoint/fabiopetroni/KILT/predictions/DPR_nicola/nq-dev-kilt.jsonl /checkpoint/fabiopetroni/KILT/datasets/nq-dev-kilt.jsonl