### PR TITLE
recall/precision computation

### DIFF
--- a/kilt/eval_retrieval.py
+++ b/kilt/eval_retrieval.py
@@ -44,7 +44,7 @@ def get_rank(datapoint, predicted_page_ids, k):
                 e_size[len(e_set)] += 1
         num_distinct_evidence_sets = len(evidence_sets)
 
-        # 2. check what's the minimum number of predicted pages needed to get a robust R@k
+        # 2. check what's the minimum number of predicted pages needed to get a robust P/R@k
         min_prediction_size = 0
         c = 0
         for size, freq in sorted(e_size.items(), reverse=True):


### PR DESCRIPTION
Implementation of evidence set aware recall/precision.
A model should produce a list of page ids.
The core idea is to group page ids that belongs to the same evidence set (consider them as 1 in the rank).
Pages that are not evidence counts as 1 as well.

test:

python kilt/eval_retrieval.py /checkpoint/fabiopetroni/KILT/predictions/DPR_nicola/nq-dev-kilt.jsonl /checkpoint/fabiopetroni/KILT/datasets/nq-dev-kilt.jsonl