### PR TITLE
Fix BibTeX snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The KILT benchmark is described in the following paper:
 ```bibtex
 @inproceedings{petroni2020kilt,
  title={KILT: a Benchmark for Knowledge Intensive Language Tasks},
- author={Fabio Petroni, Aleksandra Piktus, Angela Fan, Patrick Lewis, Majid Yazdani, Nicola De Cao, James Thorne, Yacine Jernite, Vassilis Plachouras, Tim Rockt{\"{a}}schel, Sebastian Riedel},
+ author={Fabio Petroni and Aleksandra Piktus and Angela Fan and Patrick Lewis and Majid Yazdani and Nicola De Cao and James Thorne and Yacine Jernite and Vassilis Plachouras and Tim Rockt{\"{a}}schel and Sebastian Riedel},
  booktitle={arXiv:2009.02252},
  year={2020}
 }


### PR DESCRIPTION
The use of commas as separators was confusing BibTeX:
![image](https://user-images.githubusercontent.com/107696/103830032-e88a6100-502f-11eb-9c9d-4834007e787e.png)

Using `and` fixes the problem:
![image](https://user-images.githubusercontent.com/107696/103830286-fa6c0400-502f-11eb-8100-6c8f43de922e.png)
