### PR TITLE
Fix DPR scoring order & minor README changes

### DIFF
--- a/kilt/retrievers/DPR_connector.py
+++ b/kilt/retrievers/DPR_connector.py
@@ -138,7 +138,7 @@ class DPR(Retriever):
             element = {"id": str(query_id), "retrieved": []}
 
             # sort by score in descending order
-            for score, id in sorted(zip(scores, top_ids)):
+            for score, id in sorted(zip(scores, top_ids), reverse=True):
 
                 text = self.all_passages[id][0]
                 index = self.all_passages[id][1]

--- a/kilt/retrievers/README.md
+++ b/kilt/retrievers/README.md
@@ -6,11 +6,6 @@ pip install -e git+https://github.com/facebookresearch/DrQA#egg=DrQA
 pip install pexpect==4.8
 ```
 
-change line 36 of `src/drqa/drqa/retriever/utils.py` to
-```python
-loader = np.load(filename, allow_pickle=True)
-```
-
 ## download models
 
 Download the following files in the `models` folder.
@@ -27,15 +22,6 @@ python scripts/execute_retrieval.py -m drqa -o predictions/drqa
 ## install
 ```bash
 pip install -e git+https://github.com/facebookresearch/DPR.git#egg=DPR
-```
-
-change line 185 of `src/dpr/dense_retriever.py` to
-
-```python
-try:
-    db_id, doc_vector = doc
-except:
-    title, db_id, doc_vector = doc
 ```
 
 ## download models
@@ -61,7 +47,7 @@ pip install -e git+https://github.com/facebookresearch/BLINK.git#egg=BLINK
 
 ## download models
 
-Download files in the `models` folder using the following script: [download_models.sh](https://github.com/facebookresearch/BLINK/blob/master/download_models.sh)
+Download files in the `models` folder using the following script: [download_models.sh](https://github.com/facebookresearch/BLINK/blob/master/download_blink_models.sh)
 
 And this file:
 - [Wikipedia_title2id.p](http://dl.fbaipublicfiles.com/KILT/Wikipedia_title2id.p)

--- a/kilt/retrievers/README.md
+++ b/kilt/retrievers/README.md
@@ -26,7 +26,7 @@ python scripts/execute_retrieval.py -m drqa -o predictions/drqa
 
 ## install
 ```bash
-pip install -e git+git@github.com:facebookresearch/DPR.git#egg=DPR
+pip install -e git+https://github.com/facebookresearch/DPR.git#egg=DPR
 ```
 
 change line 185 of `src/dpr/dense_retriever.py` to
@@ -56,7 +56,7 @@ python scripts/execute_retrieval.py -m dpr -o predictions/dpr
 
 ## install
 ```bash
-pip install -e git+git@github.com:facebookresearch/BLINK.git#egg=BLINK
+pip install -e git+https://github.com/facebookresearch/BLINK.git#egg=BLINK
 ```
 
 ## download models


### PR DESCRIPTION
Made the following changes:
* Updated retriever README:
    * use https to pull retriever code. 
    * removing the need to modify the source code of retreivers. I tested out not making the changes, and it didn't affect anything.
    * updated URL of blink download script.
* Fixed the scores returned by DPR so they are sorted from high to low. 

This pull request should address issues https://github.com/facebookresearch/KILT/issues/23 and https://github.com/facebookresearch/KILT/issues/22