### PR TITLE
Enable changing the default rank computation in eval_retrieval

### DIFF
--- a/kilt/eval_downstream.py
+++ b/kilt/eval_downstream.py
@@ -239,7 +239,7 @@ def evaluate(gold, guess):
     result = _calculate_metrics(gold_records, guess_records)
 
     # 2. retrieval performance
-    retrieval_results = retrieval_metrics.compute(
+    retrieval_results = retrieval_metrics.get_ranking_metrics(
         gold_records, guess_records, ks=[1, 5], rank_keys=["wikipedia_id"]
     )
     result["retrieval"] = {


### PR DESCRIPTION
- Future datasets do require a different rank computation. What this PR does is adding the argument `compute_rank_for_item_func` to the call to the evaluation: 
`evaluate(args.gold, args.guess, args.ks, args.rank_keys, compute_rank_for_item_func=compute_rank_for_item)
`
- `compute_rank_for_item_func` is reached through . 
- I changed a few function names for readability.
- All of this could also be achieved by putting all functions into a class `RetrievalEvaluator`  such that `compute_rank_for_item` or other methods can be overridden. 



