### PR TITLE
Update deprecated Mongo function to count documents

### DIFF
--- a/kilt/knowledge_source.py
+++ b/kilt/knowledge_source.py
@@ -84,7 +84,7 @@ class KnowledgeSource:
         return cursor
 
     def get_num_pages(self):
-        return self.db.count()
+        return self.db.estimated_document_count()
 
     def get_page_by_id(self, wikipedia_id):
         page = self.db.find_one({"_id": str(wikipedia_id)})


### PR DESCRIPTION
Recent PyMongo versions [don't support](https://www.reddit.com/r/mongodb/comments/aaq7m5/why_deprecate_cursorcount/) `count` on the `Collection` object anymore. 

A more accurate replacement is `count_documents({})` (empty filter) which is also [much much slower](https://stackoverflow.com/questions/52236594/why-is-pymongo-count-documents-is-slower-than-count). The replacement in this PR, `estimated_document_count` internally does the same as `count` did, therefore no regressions should happen (tested and got the same results).

This may seems like a trivial micro-PR but anyone cloning this repository with new PyMongo installed will get an error on the example code.