### PR TITLE
Add install requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,17 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.7",
+    install_requires=[
+        "bs4",
+        "flair",
+        "jsonlines",
+        "nltk",
+        "prettytable",
+        "pymongo",
+        "pytest",
+        "rouge",
+        "spacy>=2.1.8",
+        "torch",
+        "tqdm",
+    ],
 )


### PR DESCRIPTION
This way running 
```
pip install -e git+https://github.com/facebookresearch/KILT#egg=KILT
```
will automatically install all the necessary requirements.